### PR TITLE
Update/fix DataRange so it will normalize and denormalize in proportion

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,10 +134,10 @@ impl Supercluster {
             match &self.options.coordinate_system {
                 CoordinateSystem::Cartesian { range } => {
                     // X Coordinate
-                    data.push(range.normalize_x(coordinates[0]));
+                    data.push(range.normalize(coordinates[0]));
 
                     // Y Coordinate
-                    data.push(range.normalize_y(coordinates[1]));
+                    data.push(range.normalize(coordinates[1]));
                 }
                 CoordinateSystem::LatLng => {
                     // Longitude
@@ -190,10 +190,10 @@ impl Supercluster {
         let tree = &self.trees[self.limit_zoom(zoom)];
         let ids = match &self.options.coordinate_system {
             CoordinateSystem::Cartesian { range } => tree.range(
-                range.normalize_x(bbox[0]),
-                range.normalize_y(bbox[1]),
-                range.normalize_x(bbox[2]),
-                range.normalize_y(bbox[3]),
+                range.normalize(bbox[0]),
+                range.normalize(bbox[1]),
+                range.normalize(bbox[2]),
+                range.normalize(bbox[3]),
             ),
             CoordinateSystem::LatLng => {
                 let mut min_lng = ((((bbox[0] + 180.0) % 360.0) + 360.0) % 360.0) - 180.0;
@@ -539,8 +539,8 @@ impl Supercluster {
                         if let Point(coordinates) = &geometry.value {
                             match &self.options.coordinate_system {
                                 CoordinateSystem::Cartesian { range } => {
-                                    px = range.normalize_x(coordinates[0]);
-                                    py = range.normalize_y(coordinates[1]);
+                                    px = range.normalize(coordinates[0]);
+                                    py = range.normalize(coordinates[1]);
                                 }
                                 CoordinateSystem::LatLng => {
                                     px = lng_x(coordinates[0]);
@@ -743,8 +743,8 @@ fn get_cluster_json(
 ) -> Feature {
     let geometry = match coordinate_system {
         CoordinateSystem::Cartesian { range } => Geometry::new(Point(vec![
-            range.denormalize_x(data[i]),
-            range.denormalize_y(data[i + 1]),
+            range.denormalize(data[i]),
+            range.denormalize(data[i + 1]),
         ])),
         CoordinateSystem::LatLng => Geometry::new(Point(vec![x_lng(data[i]), y_lat(data[i + 1])])),
     };

--- a/src/range.rs
+++ b/src/range.rs
@@ -16,56 +16,34 @@ pub struct DataRange {
 }
 
 impl DataRange {
-    /// Normalize the x-coordinate value to the range [0, 1].
+    /// Normalize the coordinate value to the range [0, 1].
     ///
     /// # Arguments
     ///
-    /// - `x`: The x-coordinate value to be normalized.
+    /// - `v`: The coordinate value to be normalized.
     ///
     /// # Returns
     ///
-    /// The normalized x-coordinate value.
-    pub fn normalize_x(&self, x: f64) -> f64 {
-        (x - self.min_x) / (self.max_x - self.min_x)
+    /// The normalized coordinate value.
+    pub fn normalize(&self, v: f64) -> f64 {
+        let range_min = f64::min(self.min_x, self.min_y);
+        let range_max = f64::max(self.max_x, self.max_y);
+        (v - range_min) / (range_max - range_min)
     }
 
-    /// Normalize the y-coordinate value to the range [0, 1].
+    /// Denormalize the coordinate value from the range [0, 1] to the original range.
     ///
     /// # Arguments
     ///
-    /// - `y`: The y-coordinate value to be normalized.
+    /// - `v_scaled`: The scaled coordinate value to be denormalized.
     ///
     /// # Returns
     ///
-    /// The normalized y-coordinate value.
-    pub fn normalize_y(&self, y: f64) -> f64 {
-        (y - self.min_y) / (self.max_y - self.min_y)
-    }
-
-    /// Denormalize the x-coordinate value from the range [0, 1] to the original range.
-    ///
-    /// # Arguments
-    ///
-    /// - `x_scaled`: The scaled x-coordinate value to be denormalized.
-    ///
-    /// # Returns
-    ///
-    /// The denormalized x-coordinate value.
-    pub fn denormalize_x(&self, x_scaled: f64) -> f64 {
-        x_scaled * (self.max_x - self.min_x) + self.min_x
-    }
-
-    /// Denormalize the y-coordinate value from the range [0, 1] to the original range.
-    ///
-    /// # Arguments
-    ///
-    /// - `y_scaled`: The scaled y-coordinate value to be denormalized.
-    ///
-    /// # Returns
-    ///
-    /// The denormalized y-coordinate value.
-    pub fn denormalize_y(&self, y_scaled: f64) -> f64 {
-        y_scaled * (self.max_y - self.min_y) + self.min_y
+    /// The denormalized coordinate value.
+    pub fn denormalize(&self, v_scaled: f64) -> f64 {
+        let range_min = f64::min(self.min_x, self.min_y);
+        let range_max = f64::max(self.max_x, self.max_y);
+        v_scaled * (range_max - range_min) + range_min
     }
 }
 
@@ -82,18 +60,12 @@ mod tests {
             max_y: 50.0,
         };
 
-        assert_eq!(data_range.normalize_x(-10.0), 0.0);
-        assert_eq!(data_range.normalize_x(45.0), 0.5);
-        assert_eq!(data_range.normalize_x(100.0), 1.0);
-        assert_eq!(data_range.normalize_y(-20.0), 0.0);
-        assert_eq!(data_range.normalize_y(15.0), 0.5);
-        assert_eq!(data_range.normalize_y(50.0), 1.0);
+        assert_eq!(data_range.normalize(-20.0), 0.0);
+        assert_eq!(data_range.normalize(40.0), 0.5);
+        assert_eq!(data_range.normalize(100.0), 1.0);
 
-        assert_eq!(data_range.denormalize_x(0.0), -10.0);
-        assert_eq!(data_range.denormalize_x(0.5), 45.0);
-        assert_eq!(data_range.denormalize_x(1.0), 100.0);
-        assert_eq!(data_range.denormalize_y(0.0), -20.0);
-        assert_eq!(data_range.denormalize_y(0.5), 15.0);
-        assert_eq!(data_range.denormalize_y(1.0), 50.0);
+        assert_eq!(data_range.denormalize(0.0), -20.0);
+        assert_eq!(data_range.denormalize(0.5), 40.0);
+        assert_eq!(data_range.denormalize(1.0), 100.0);
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -45,6 +45,7 @@ pub fn get_data_range(data: &Vec<Feature>) -> Option<DataRange> {
             max_x,
             min_y,
             max_y,
+            ..Default::default()
         })
     } else {
         None


### PR DESCRIPTION
## 📇 Description

Updates DataRange to take the min/max of the given range to ensure that tile output is proportional.

### 🚨 Checklist

- [ ] My changes do not introduce backwards compatibility issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have actively considered and searched for potential security issues and did address these.

### 🧪 Tests

- [x] I have added missing tests for related code.
- [x] I have manually tested my code for regression on existing functionality.
- [x] I have added tests that prove my fix is effective or that my feature works.
